### PR TITLE
Refresh tokens on demand instead of for every request

### DIFF
--- a/Source/IsthereanydealClient.cs
+++ b/Source/IsthereanydealClient.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Security.Principal;
@@ -29,6 +30,7 @@ namespace IsthereanydealCollectionSync
         private readonly string tokensPath;
         private readonly ILogger logger;
         private readonly Plugin plugin;
+        private OauthToken token;
 
         public IsthereanydealClient(Plugin plugin, ILogger logger)
         {
@@ -120,9 +122,8 @@ namespace IsthereanydealCollectionSync
                 HttpResponseMessage tokenResponse = await client.PostAsync("https://isthereanydeal.com/oauth/token/", content);
                 tokenResponse.EnsureSuccessStatusCode();
                 var tokenResponseContent = await tokenResponse.Content.ReadAsStringAsync();
-                var authData = Serialization.FromJson<OauthToken>(tokenResponseContent);
-                // TODO: Store timestamp to check against expiration? (right now we just always refresh the token anyway though, which works fine but is inefficent)
-                if (authData.refresh_token != null)
+                token = Serialization.FromJson<OauthToken>(tokenResponseContent);
+                if (token.refresh_token != null)
                 {
                     // TODO: maybe encrypt like the official extensions do
                     using (FileStream fileStream = new FileStream(tokensPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true))
@@ -134,35 +135,30 @@ namespace IsthereanydealCollectionSync
             }
         }
 
-        private async Task<OauthToken> RefreshTokens(OauthToken token)
+        private async Task RefreshTokens(HttpClient client)
         {
             try
             {
-                using (var client = new HttpClient())
-                {
-                    var parameters = new Dictionary<string, string>
+                var parameters = new Dictionary<string, string>
                     {
                         { "grant_type", "refresh_token" },
                         { "client_id", CLIENT_ID },
                         { "refresh_token", token.refresh_token },
                     };
-                    var content = new FormUrlEncodedContent(parameters);
-                    HttpResponseMessage tokenResponse = await client.PostAsync("https://isthereanydeal.com/oauth/token/", content);
-                    tokenResponse.EnsureSuccessStatusCode();
-                    var tokenResponseContent = await tokenResponse.Content.ReadAsStringAsync();
-                    var authData = Serialization.FromJson<OauthToken>(tokenResponseContent);
-                    // TODO: Store timestamp to check against expiration? (right now we just always refresh the token anyway though, which works fine but is inefficent)
-                    if (authData.refresh_token == null)
-                    {
-                        throw new ITADException("Received invalid token");
-                    }
-                    // TODO: maybe encrypt like the official extensions do
-                    using (FileStream fileStream = new FileStream(tokensPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true))
-                    {
-                        byte[] data = Encoding.UTF8.GetBytes(tokenResponseContent);
-                        await fileStream.WriteAsync(data, 0, data.Length);
-                        return authData;
-                    }
+                var content = new FormUrlEncodedContent(parameters);
+                HttpResponseMessage tokenResponse = await client.PostAsync("https://isthereanydeal.com/oauth/token/", content);
+                tokenResponse.EnsureSuccessStatusCode();
+                var tokenResponseContent = await tokenResponse.Content.ReadAsStringAsync();
+                token = Serialization.FromJson<OauthToken>(tokenResponseContent);
+                if (token.refresh_token == null)
+                {
+                    throw new ITADException("Received invalid token");
+                }
+                // TODO: maybe encrypt like the official extensions do
+                using (FileStream fileStream = new FileStream(tokensPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true))
+                {
+                    byte[] data = Encoding.UTF8.GetBytes(tokenResponseContent);
+                    await fileStream.WriteAsync(data, 0, data.Length);
                 }
             }
             catch (Exception ex)
@@ -171,28 +167,24 @@ namespace IsthereanydealCollectionSync
             }
         }
 
-        private async Task<ProfilesLinkResponse> LinkProfile(OauthToken token)
+        private async Task<ProfilesLinkResponse> LinkProfile(HttpClient client)
         {
             try
             {
-                using (var client = new HttpClient())
+                // NOTE: Using a constant accountId, even though the docs suggest it should be unique per user, this _seems_ to work ok
+                // TODO: However, the extension probably should let people optionally configure the accountId in case they have multiple Playnite installs on different computers syncing to ITAD?
+                // TODO probably move this to ProfilesSyncCollection as a class
+                var response = await Send<ProfilesLinkResponse>(
+                    client,
+                    HttpMethod.Put,
+                    new StringContent("{\"accountId\": \"playnite\", \"accountName\": \"Playnite\" }"),
+                    "https://api.isthereanydeal.com/profiles/link/v1");
+
+                if (string.IsNullOrEmpty(response?.token))
                 {
-                    client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token.access_token);
-                    // NOTE: Using a constant accountId, even though the docs suggest it should be unique per user, this _seems_ to work ok
-                    // TODO: However, the extension probably should let people optionally configure the accountId in case they have multiple Playnite installs on different computers syncing to ITAD?
-                    // TODO probably move this to ProfilesSyncCollection as a class
-                    var body = new StringContent("{\"accountId\": \"playnite\", \"accountName\": \"Playnite\" }");
-                    HttpResponseMessage response = await client.PutAsync("https://api.isthereanydeal.com/profiles/link/v1", body);
-                    response.EnsureSuccessStatusCode();
-                    var responseContent = await response.Content.ReadAsStringAsync();
-                    var profilesLinkResponse = Serialization.FromJson<ProfilesLinkResponse>(responseContent);
-                    // TODO: Store timestamp to check against expiration? (right now we just always refresh the token anyway though)
-                    if (string.IsNullOrEmpty(profilesLinkResponse.token))
-                    {
-                        throw new ITADException("Received invalid profile token");
-                    }
-                    return profilesLinkResponse;
+                    throw new ITADException("Received invalid profile token");
                 }
+                return response;
             }
             catch (Exception ex)
             {
@@ -236,21 +228,21 @@ namespace IsthereanydealCollectionSync
 
             using (var client = new HttpClient())
             {
-                var oauthToken = await getToken();
-                var refreshedOauthToken = await RefreshTokens(oauthToken);
-                var profileToken = await LinkProfile(refreshedOauthToken);
+                token = await getToken();
+                var profileToken = await LinkProfile(client);
 
                 try
                 {
-                    client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", refreshedOauthToken.access_token);
                     client.DefaultRequestHeaders.Add("ITAD-Profile", profileToken.token);
                     var bodyContent = Serialization.ToJson(gamesRequest);
                     var body = new StringContent(bodyContent, Encoding.UTF8, "application/json");
-                    HttpResponseMessage response = await client.PutAsync("https://api.isthereanydeal.com/profiles/sync/collection/v1", body);
-                    response.EnsureSuccessStatusCode();
-                    var responseContent = await response.Content.ReadAsStringAsync();
-                    var profilesSyncCollectionResponse = Serialization.FromJson<ProfilesSyncCollectionResponse>(responseContent);
-                    return profilesSyncCollectionResponse;
+                    var response = await Send< ProfilesSyncCollectionResponse>(
+                        client,
+                        HttpMethod.Put,
+                        body,
+                        "https://api.isthereanydeal.com/profiles/sync/collection/v1");
+
+                    return response;
                 }
                 catch (Exception ex)
                 {
@@ -283,15 +275,60 @@ namespace IsthereanydealCollectionSync
         {
             try
             {
-                var oauthToken = await getToken();
-                var refreshedOauthToken = await RefreshTokens(oauthToken);
-                return refreshedOauthToken != null;
+                using (var client = new HttpClient())
+                {
+                    token = await getToken();
+                    await RefreshTokens(client);
+                    return token != null;
+                }
             }
             catch (Exception ex)
             {
                 logger.Warn(ex, "Error checking GetIsUserLoggedIn");
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Send a request with bearer authentication. It will
+        /// refresh the tokens and send again if the initial
+        /// response is "Unauthorized" (401). You do not need
+        /// to set Authorization header before calling.
+        /// </summary>
+        /// <typeparam name="Response">The datatype of this request's response that will be deserialized into</typeparam>
+        /// <param name="client">Required: Client to send request</param>
+        /// <param name="method">Required: Request method</param>
+        /// <param name="content">Nullable: Request body</param>
+        /// <param name="uri">Required: Request URI</param>
+        /// <returns>Response from <paramref name="uri"/>.</returns>
+        private async Task<Response> Send<Response>(
+            HttpClient client, // required
+            HttpMethod method, // required
+            HttpContent content, // nullable
+            string uri) // required
+        where Response: class
+        {
+            var msg = new HttpRequestMessage(method, uri)
+            {
+                Content = content
+            };
+
+            msg.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token.access_token);
+            var response = await client.SendAsync(msg);
+
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                await RefreshTokens(client);
+                client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token.access_token);
+                msg = new HttpRequestMessage(method, uri)
+                {
+                    Content = content
+                };
+                response = await client.SendAsync(msg);
+            }
+
+            response.EnsureSuccessStatusCode();
+            return Serialization.FromJsonStream<Response>(await response.Content.ReadAsStreamAsync());
         }
     }
 

--- a/Source/IsthereanydealClient.cs
+++ b/Source/IsthereanydealClient.cs
@@ -145,7 +145,6 @@ namespace IsthereanydealCollectionSync
                         { "grant_type", "refresh_token" },
                         { "client_id", CLIENT_ID },
                         { "refresh_token", token.refresh_token },
-                        { "scope", SCOPE },
                     };
                     var content = new FormUrlEncodedContent(parameters);
                     HttpResponseMessage tokenResponse = await client.PostAsync("https://isthereanydeal.com/oauth/token/", content);

--- a/Source/IsthereanydealClient.cs
+++ b/Source/IsthereanydealClient.cs
@@ -37,22 +37,26 @@ namespace IsthereanydealCollectionSync
             this.plugin = plugin;
             this.logger = logger;
             tokensPath = Path.Combine(plugin.GetPluginUserDataPath(), "tokens.json");
+            // token is left uninitialized here, mostly because loading it may throw errors which are better handled elsewhere
         }
 
         public async Task Login()
         {
             var pkce = new Pkce();
 
+            // Logout any existing session by deleting old tokens
             try
             {
                 if (File.Exists(tokensPath))
                 {
                     File.Delete(tokensPath);
                 }
-            } catch (Exception ex)
+            }
+            catch (Exception ex)
             {
                 throw new ITADException("Failed to delete old tokens file on login", ex);
             }
+            token = null;
 
             var loginUrl = $"https://isthereanydeal.com/oauth/authorize/?client_id={CLIENT_ID}&response_type=code&code_challenge_method=S256&code_challenge={pkce.codeChallenge}&state={pkce.state}&scope={SCOPE}&redirect_uri={Uri.EscapeDataString(REDIRECT_URI)}";
             var brokenPostSteamLoginUrl = $"https://isthereanydeal.com/oauth/authorize/?client_id={CLIENT_ID}";
@@ -79,7 +83,7 @@ namespace IsthereanydealCollectionSync
                         webView.Close();
                     }
                 };
-                webView.DeleteDomainCookies("isthereanydeal.com");
+                webView.DeleteDomainCookies("isthereanydeal.com");  // Logout inside webview by deleting cookies
                 webView.Navigate(loginUrl);
                 webView.OpenDialog();
             }
@@ -92,7 +96,7 @@ namespace IsthereanydealCollectionSync
                     // Query is inside the URL fragment because we used a # redirect URI
                     var query = uri.Fragment.Substring(uri.Fragment.IndexOf("?") + 1);
                     var queryParams = HttpUtility.ParseQueryString(query);
-                    await Authenticate(queryParams.Get("state"), queryParams.Get("code"), pkce);
+                    token = await Authenticate(queryParams.Get("state"), queryParams.Get("code"), pkce);
                 }
                 catch (Exception ex)
                 {
@@ -101,7 +105,7 @@ namespace IsthereanydealCollectionSync
             }
         }
 
-        private async Task Authenticate(string state, string code, Pkce pkce)
+        private async Task<OauthToken> Authenticate(string state, string code, Pkce pkce)
         {
             using (var client = new HttpClient())
             {
@@ -122,20 +126,22 @@ namespace IsthereanydealCollectionSync
                 HttpResponseMessage tokenResponse = await client.PostAsync("https://isthereanydeal.com/oauth/token/", content);
                 tokenResponse.EnsureSuccessStatusCode();
                 var tokenResponseContent = await tokenResponse.Content.ReadAsStringAsync();
-                token = Serialization.FromJson<OauthToken>(tokenResponseContent);
-                if (token.refresh_token != null)
+                var newToken = Serialization.FromJson<OauthToken>(tokenResponseContent);
+                if (newToken.refresh_token == null)
                 {
-                    // TODO: maybe encrypt like the official extensions do
-                    using (FileStream fileStream = new FileStream(tokensPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true))
-                    {
-                        byte[] data = Encoding.UTF8.GetBytes(tokenResponseContent);
-                        await fileStream.WriteAsync(data, 0, data.Length);
-                    }
+                    throw new ITADException("Received invalid token");
                 }
+                // TODO: maybe encrypt like the official extensions do
+                using (FileStream fileStream = new FileStream(tokensPath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true))
+                {
+                    byte[] data = Encoding.UTF8.GetBytes(tokenResponseContent);
+                    await fileStream.WriteAsync(data, 0, data.Length);
+                }
+                return newToken;
             }
         }
 
-        private async Task RefreshTokens(HttpClient client)
+        private async Task<OauthToken> RefreshTokens(HttpClient client)
         {
             try
             {
@@ -149,8 +155,8 @@ namespace IsthereanydealCollectionSync
                 HttpResponseMessage tokenResponse = await client.PostAsync("https://isthereanydeal.com/oauth/token/", content);
                 tokenResponse.EnsureSuccessStatusCode();
                 var tokenResponseContent = await tokenResponse.Content.ReadAsStringAsync();
-                token = Serialization.FromJson<OauthToken>(tokenResponseContent);
-                if (token.refresh_token == null)
+                var newToken = Serialization.FromJson<OauthToken>(tokenResponseContent);
+                if (newToken.refresh_token == null)
                 {
                     throw new ITADException("Received invalid token");
                 }
@@ -160,6 +166,8 @@ namespace IsthereanydealCollectionSync
                     byte[] data = Encoding.UTF8.GetBytes(tokenResponseContent);
                     await fileStream.WriteAsync(data, 0, data.Length);
                 }
+
+                return newToken;
             }
             catch (Exception ex)
             {
@@ -228,7 +236,7 @@ namespace IsthereanydealCollectionSync
 
             using (var client = new HttpClient())
             {
-                token = await getToken();
+                token = await loadSavedToken();
                 var profileToken = await LinkProfile(client);
 
                 try
@@ -236,7 +244,7 @@ namespace IsthereanydealCollectionSync
                     client.DefaultRequestHeaders.Add("ITAD-Profile", profileToken.token);
                     var bodyContent = Serialization.ToJson(gamesRequest);
                     var body = new StringContent(bodyContent, Encoding.UTF8, "application/json");
-                    var response = await Send< ProfilesSyncCollectionResponse>(
+                    var response = await Send<ProfilesSyncCollectionResponse>(
                         client,
                         HttpMethod.Put,
                         body,
@@ -251,7 +259,7 @@ namespace IsthereanydealCollectionSync
             }
         }
 
-        private async Task<OauthToken> getToken()
+        private async Task<OauthToken> loadSavedToken()
         {
             try
             {
@@ -266,7 +274,8 @@ namespace IsthereanydealCollectionSync
                     throw new ITADException("Invalid token file");
                 }
                 return oauthToken;
-            } catch (Exception ex)
+            }
+            catch (Exception ex)
             {
                 throw new ITADException("User not logged in", ex);
             }
@@ -277,8 +286,8 @@ namespace IsthereanydealCollectionSync
             {
                 using (var client = new HttpClient())
                 {
-                    token = await getToken();
-                    await RefreshTokens(client);
+                    token = await loadSavedToken();
+                    token = await RefreshTokens(client);
                     return token != null;
                 }
             }
@@ -306,8 +315,13 @@ namespace IsthereanydealCollectionSync
             HttpMethod method, // required
             HttpContent content, // nullable
             string uri) // required
-        where Response: class
+        where Response : class
         {
+            if (token?.access_token == null)
+            {
+                throw new ITADException("User not logged in");
+            }
+
             var msg = new HttpRequestMessage(method, uri)
             {
                 Content = content
@@ -318,7 +332,7 @@ namespace IsthereanydealCollectionSync
 
             if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
-                await RefreshTokens(client);
+                token = await RefreshTokens(client);
                 client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token.access_token);
                 msg = new HttpRequestMessage(method, uri)
                 {


### PR DESCRIPTION
This PR aims to resolve the following TODO:

> Store timestamp to check against expiration? (right now we just always refresh the token anyway though, which works fine but is inefficent)

It works by checking the response status of each request, and refresh the tokens when it's Unauthorized (401), and send the request again.

This is implemented separately as a method in `OauthToken` and every `client` method were replaced to use that.

### Note

It's probably possible to implement this without making methods in `OauthToken` and moving `RefreshTokens()` to there, but I personally find this more natural and easier to read.

### Misc

Some modifications were made that is not the main aim of the PR:

- The refresh token endpoint actually does not require passing scope, so it's removed.
- Reuse `HttpClient` in some places, as per [.NET guideline](https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines#pooled-connections).
- Use [/user/info/v2](https://docs.isthereanydeal.com/#tag/User/operation/user-info-v2) to check user login. This removes serialization and disk IO that happens every time the user open the settings. As a result, `user_info` scope is required, so re-authentication is needed (and as a side-effect of this authentication, this creates a new linking profile, so unlinking the previous one is needed).