### PR TITLE
Show success dialog on foreground sync

### DIFF
--- a/Source/IsthereanydealCollectionSync.cs
+++ b/Source/IsthereanydealCollectionSync.cs
@@ -5,14 +5,8 @@ using Playnite.SDK.Models;
 using Playnite.SDK.Plugins;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
-using System.Web.UI.WebControls;
-using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Interop;
 
 namespace IsthereanydealCollectionSync
 {
@@ -81,9 +75,11 @@ namespace IsthereanydealCollectionSync
                 return;
             }
 
+
+            ProfilesSyncCollectionResponse result = null;
             try
             {
-                var result = await client.ProfilesSyncCollection(games);
+                result = await client.ProfilesSyncCollection(games);
             }
             catch (ITADException ex)
             {
@@ -108,9 +104,13 @@ namespace IsthereanydealCollectionSync
                 PlayniteApi.Dialogs.ShowErrorMessage($"Unexpected error during ITAD collection sync:\n{ex.Message}", ResourceProvider.GetString("LOCIsThereAnyDealCollectionSync"));
             }
 
-            // TODO: if foreground, show success dialog with info from server.
-            // probably no notification at all for background success?
+            if (!background)
+            {
+                // TODO: localize
+                PlayniteApi.Dialogs.ShowMessage($"IsThereAnyDeal profile synced successfully\n\n{result?.total} total games synced\n{result?.added} new games added\n{result?.removed} games removed", ResourceProvider.GetString("LOCIsThereAnyDealCollectionSync"));
+            }
         }
+
         internal void ClearNotifications()
         {
             // Playnite doesn't care if we delete a non-existing notification


### PR DESCRIPTION
Show a success dialog on foreground sync with total/added/removed count from API response.

This still has no indication of success for a background sync, which I think is fine. We could create a notification but it would make the notification counter increase and those usually are all errors. I don't think I'd want to always see a 1 notification that just says success every time I open Playnite. I could be convinced otherwise though, maybe others want a notification to always show for background sync.